### PR TITLE
Investigate current employees dashboard issue

### DIFF
--- a/src/pages/DashboardPage.tsx
+++ b/src/pages/DashboardPage.tsx
@@ -131,7 +131,7 @@ const DashboardPage: React.FC = () => {
         <div className="grid grid-cols-2 lg:grid-cols-4 gap-4 sm:gap-6 mb-6 sm:mb-8">
             <Card className="group bg-gradient-to-br from-card via-card to-primary/5 border-primary/20 shadow-card hover:shadow-elegant transition-all duration-300 hover:scale-[1.02] cursor-pointer rounded-xl overflow-hidden">
                 <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2 p-4 sm:p-6">
-                    <CardTitle className="text-sm font-semibold text-card-foreground/80">{getPeriodLabel()} Employees</CardTitle>
+                    <CardTitle className="text-sm font-semibold text-card-foreground/80">Total Employees</CardTitle>
                     <div className="p-2 bg-primary/10 rounded-lg group-hover:bg-primary/20 transition-colors"><Users className="h-4 w-4 text-primary" /></div>
                 </CardHeader>
                 <CardContent className="p-4 sm:p-6 pt-0">

--- a/supabase/migrations/20250728194204-fix-dashboard-employee-count.sql
+++ b/supabase/migrations/20250728194204-fix-dashboard-employee-count.sql
@@ -1,0 +1,43 @@
+-- Fix dashboard employee count to show total active employees instead of just those who worked in the period
+-- This addresses the issue where "Current Employees" shows only employees who worked during the selected period
+
+CREATE OR REPLACE FUNCTION public.get_dashboard_stats(from_date text, to_date text)
+ RETURNS json
+ LANGUAGE plpgsql
+ SET search_path TO 'public'
+AS $function$
+DECLARE
+  v_employee_count int;
+  v_total_hours numeric;
+  v_total_payroll numeric;
+  v_total_shifts int;
+BEGIN
+  -- Get total count of all employees in the system (active staff members)
+  -- This represents the actual number of employees in the company
+  SELECT COUNT(*) INTO v_employee_count 
+  FROM public.employees;
+
+  -- Aggregate timesheet data within the specified date range
+  -- These metrics are still period-specific as they should be
+  SELECT
+    COALESCE(SUM(total_hours), 0),
+    COALESCE(SUM(COALESCE(total_card_amount_split, total_card_amount_flat)), 0),
+    COUNT(id)
+  INTO
+    v_total_hours,
+    v_total_payroll,
+    v_total_shifts
+  FROM
+    public.timesheet_entries
+  WHERE
+    clock_in_date >= from_date::date AND clock_in_date <= to_date::date;
+
+  -- Return all stats as a single JSON object
+  RETURN json_build_object(
+    'employeeCount', v_employee_count,
+    'totalHours', v_total_hours,
+    'totalPayroll', v_total_payroll,
+    'totalShifts', v_total_shifts
+  );
+END;
+$function$;


### PR DESCRIPTION
Fixes dashboard 'Current Employees' count to show total staff members by updating the database function and dashboard label.

The original `get_dashboard_stats` function incorrectly calculated "Current Employees" by counting only those with timesheet entries within the selected period. This resulted in the dashboard showing a low, period-dependent number (e.g., '1') instead of the actual total number of active staff. This PR updates the function to count all employees in the `public.employees` table and clarifies the dashboard label to "Total Employees" for accuracy.

---

[Open in Web](https://cursor.com/agents?id=bc-d582e9c2-7180-499b-8d2f-357587f68ee5) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-d582e9c2-7180-499b-8d2f-357587f68ee5) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)