### PR TITLE
Investigate render deployment failure

### DIFF
--- a/src/pages/ClockInOutPage.tsx
+++ b/src/pages/ClockInOutPage.tsx
@@ -129,11 +129,12 @@ const ClockInOutPage: React.FC = () => {
 
       // Process team member statuses
       const statusMap = new Map<string, TeamMemberStatus>();
+      const currentTime = await getCurrentCompanyTime();
       
       timesheetData?.forEach(entry => {
         const isActive = !entry.clock_out_time || entry.clock_out_time === '00:00:00';
         const duration = isActive 
-          ? differenceInMinutes(await getCurrentCompanyTime(), new Date(`${entry.clock_in_date}T${entry.clock_in_time}`))
+          ? differenceInMinutes(currentTime, new Date(`${entry.clock_in_date}T${entry.clock_in_time}`))
           : entry.total_hours ? entry.total_hours * 60 : 0;
 
         // Map employee ID/name to display name


### PR DESCRIPTION
Fixes "await" syntax error in `ClockInOutPage.tsx` by moving `getCurrentCompanyTime()` call outside `forEach` loop to enable successful builds.

---
<a href="https://cursor.com/background-agent?bcId=bc-ac8f6d46-7b1c-4de3-902b-59bfc2e24ccb">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ac8f6d46-7b1c-4de3-902b-59bfc2e24ccb">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>