### PR TITLE
Fix clockin page egypt time zone

### DIFF
--- a/src/pages/ClockInOutPage.tsx
+++ b/src/pages/ClockInOutPage.tsx
@@ -12,7 +12,7 @@ import { format, differenceInMinutes, startOfDay, addHours } from 'date-fns';
 import { toast } from 'sonner';
 import ProfileAvatar from '@/components/ProfileAvatar';
 import { getCurrentCompanyTime, getTodayInCompanyTimezone, formatInCompanyTimezone, getCompanyTimezone, validateTimezone, parseCompanyDateTime } from '@/utils/timezoneUtils';
-import { getTimezoneAbbreviation } from '@/utils/timeFormatter';
+import { getTimezoneAbbreviation, formatTimeToAMPM } from '@/utils/timeFormatter';
 
 // Defines the structure for a clock-in/out entry
 interface ClockEntry {
@@ -601,7 +601,7 @@ const ClockInOutPage: React.FC = () => {
                   <div className="flex items-center justify-between text-xs text-muted-foreground">
                     <div className="flex items-center space-x-1">
                       <Timer className="h-3 w-3" />
-                      <span>Since {format(new Date(`${currentEntry.clock_in_date}T${currentEntry.clock_in_time.split('.')[0]}`), 'h:mm:ss a')}</span>
+                      <span>Since {formatTimeToAMPM(currentEntry.clock_in_time.split('.')[0])}</span>
                     </div>
                     {getTimeUntilTarget() && (
                       <div className="flex items-center space-x-1">
@@ -739,7 +739,7 @@ const ClockInOutPage: React.FC = () => {
               {currentEntry && (
                 <div className="pt-2 border-t">
                   <div>Entry ID: {currentEntry.id}</div>
-                                      <div>Clock In: {currentEntry.clock_in_date} {format(new Date(`${currentEntry.clock_in_date}T${currentEntry.clock_in_time.split('.')[0]}`), 'h:mm:ss a')}</div>
+                                      <div>Clock In: {currentEntry.clock_in_date} {formatTimeToAMPM(currentEntry.clock_in_time.split('.')[0])}</div>
                   <div>Employee Name: {currentEntry.employee_name}</div>
                   <div>Clock In Location: {currentEntry.clock_in_location || 'N/A'}</div>
                 </div>
@@ -812,7 +812,7 @@ const ClockInOutPage: React.FC = () => {
                             <p className="font-semibold text-sm">{member.employee_name}</p>
                             <div className="flex items-center space-x-2 text-xs text-muted-foreground">
                               <Clock className="h-3 w-3" />
-                              <span>Started at {format(new Date(`${member.clock_in_date}T${member.clock_in_time.split('.')[0]}`), 'h:mm a')}</span>
+                              <span>Started at {formatTimeToAMPM(member.clock_in_time.split('.')[0])}</span>
                             </div>
                           </div>
                         </div>
@@ -875,7 +875,7 @@ const ClockInOutPage: React.FC = () => {
                           </div>
                           <div>
                             <span className="text-sm font-semibold">Clock In</span>
-                            <p className="text-lg font-bold text-success">{format(new Date(`${entry.clock_in_date}T${entry.clock_in_time.split('.')[0]}`), 'h:mm a')}</p>
+                            <p className="text-lg font-bold text-success">{formatTimeToAMPM(entry.clock_in_time.split('.')[0])}</p>
                           </div>
                         </div>
                         
@@ -886,7 +886,7 @@ const ClockInOutPage: React.FC = () => {
                             </div>
                             <div>
                               <span className="text-sm font-semibold">Clock Out</span>
-                              <p className="text-lg font-bold text-destructive">{format(new Date(`${entry.clock_out_date}T${entry.clock_out_time.split('.')[0]}`), 'h:mm a')}</p>
+                              <p className="text-lg font-bold text-destructive">{formatTimeToAMPM(entry.clock_out_time.split('.')[0])}</p>
                             </div>
                           </div>
                         )}

--- a/src/pages/ClockInOutPage.tsx
+++ b/src/pages/ClockInOutPage.tsx
@@ -282,7 +282,7 @@ const ClockInOutPage: React.FC = () => {
         // Calculate worked hours if clocked in
         if (currentEntry) {
           // Parse the clock-in time as company timezone and convert to UTC for proper comparison
-          const clockInDateTimeStr = `${currentEntry.clock_in_date} ${currentEntry.clock_in_time}`;
+          const clockInDateTimeStr = `${currentEntry.clock_in_date} ${currentEntry.clock_in_time.split('.')[0]}`;
           const clockInDateTime = await parseCompanyDateTime(clockInDateTimeStr);
           const minutesWorked = differenceInMinutes(utcNow, clockInDateTime);
           setWorkedHours(minutesWorked / 60);
@@ -601,7 +601,7 @@ const ClockInOutPage: React.FC = () => {
                   <div className="flex items-center justify-between text-xs text-muted-foreground">
                     <div className="flex items-center space-x-1">
                       <Timer className="h-3 w-3" />
-                      <span>Since {currentEntry.clock_in_time}</span>
+                      <span>Since {format(new Date(`${currentEntry.clock_in_date}T${currentEntry.clock_in_time.split('.')[0]}`), 'h:mm:ss a')}</span>
                     </div>
                     {getTimeUntilTarget() && (
                       <div className="flex items-center space-x-1">
@@ -739,7 +739,7 @@ const ClockInOutPage: React.FC = () => {
               {currentEntry && (
                 <div className="pt-2 border-t">
                   <div>Entry ID: {currentEntry.id}</div>
-                  <div>Clock In: {currentEntry.clock_in_date} {currentEntry.clock_in_time}</div>
+                                      <div>Clock In: {currentEntry.clock_in_date} {format(new Date(`${currentEntry.clock_in_date}T${currentEntry.clock_in_time.split('.')[0]}`), 'h:mm:ss a')}</div>
                   <div>Employee Name: {currentEntry.employee_name}</div>
                   <div>Clock In Location: {currentEntry.clock_in_location || 'N/A'}</div>
                 </div>
@@ -812,7 +812,7 @@ const ClockInOutPage: React.FC = () => {
                             <p className="font-semibold text-sm">{member.employee_name}</p>
                             <div className="flex items-center space-x-2 text-xs text-muted-foreground">
                               <Clock className="h-3 w-3" />
-                              <span>Started at {member.clock_in_time}</span>
+                              <span>Started at {format(new Date(`${member.clock_in_date}T${member.clock_in_time.split('.')[0]}`), 'h:mm a')}</span>
                             </div>
                           </div>
                         </div>
@@ -875,7 +875,7 @@ const ClockInOutPage: React.FC = () => {
                           </div>
                           <div>
                             <span className="text-sm font-semibold">Clock In</span>
-                            <p className="text-lg font-bold text-success">{entry.clock_in_time}</p>
+                            <p className="text-lg font-bold text-success">{format(new Date(`${entry.clock_in_date}T${entry.clock_in_time.split('.')[0]}`), 'h:mm a')}</p>
                           </div>
                         </div>
                         
@@ -886,7 +886,7 @@ const ClockInOutPage: React.FC = () => {
                             </div>
                             <div>
                               <span className="text-sm font-semibold">Clock Out</span>
-                              <p className="text-lg font-bold text-destructive">{entry.clock_out_time}</p>
+                              <p className="text-lg font-bold text-destructive">{format(new Date(`${entry.clock_out_date}T${entry.clock_out_time.split('.')[0]}`), 'h:mm a')}</p>
                             </div>
                           </div>
                         )}


### PR DESCRIPTION
Standardize time display format on the clock-in page to ensure consistency and proper 12-hour AM/PM formatting, addressing raw database time value discrepancies.

---
<a href="https://cursor.com/background-agent?bcId=bc-b0d68672-d7ac-4d08-9dff-2eac22fdd65e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b0d68672-d7ac-4d08-9dff-2eac22fdd65e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

