### PR TITLE
Fix render application issue

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -13,7 +13,12 @@ export default defineConfig(({ mode }) => ({
   preview: {
     host: "::",
     port: 4173,
-    allowedHosts: "all",
+    // Allow all Render deployment sub-domains as well as the specific production host
+    // A leading dot matches any sub-domain of the specified suffix (e.g. *.onrender.com)
+    allowedHosts: [
+      ".onrender.com", // any Render app
+      "gabalaya-time-insight.onrender.com" // current production host
+    ],
     cors: true,
   },
   plugins: [


### PR DESCRIPTION
Update Vite's `preview.allowedHosts` to resolve 'Blocked request' errors on Render deployments.

---
<a href="https://cursor.com/background-agent?bcId=bc-fd0cc70d-38f1-4608-8630-a88675384530">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-fd0cc70d-38f1-4608-8630-a88675384530">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

